### PR TITLE
fix: copy code-server failed on second launch

### DIFF
--- a/lib/terminal_controller.dart
+++ b/lib/terminal_controller.dart
@@ -202,7 +202,7 @@ class HomeController extends GetxController {
   }
 
   Future<void> loadCodeServer() async {
-    loadCodeVersion();
+    await loadCodeVersion();
     bumpProgress();
     // 创建相关文件夹
     // Create related folders
@@ -237,10 +237,14 @@ class HomeController extends GetxController {
       if (useCustomCodeServer) {
         File codeServerOnSdcard = File(sourcePath);
         File targetFile = File('${RuntimeEnvir.tmpPath}/$codeServerName');
-        if (targetFile.lengthSync() == codeServerOnSdcard.lengthSync()) {
-          Log.i('code server already copied, skip');
+        if (targetFile.existsSync() && targetFile.lengthSync() == codeServerOnSdcard.lengthSync()) {
+          Log.i('code server already copied to tmp, skip');
+        } else {
+          if (targetFile.existsSync()) {
+            targetFile.deleteSync();
+          }
+          await codeServerOnSdcard.copy(targetFile.path);
         }
-        await codeServerOnSdcard.copy(targetFile.path);
       } else {
         await AssetsUtils.copyAssetToPath(
           sourcePath,


### PR DESCRIPTION
Fix two bugs causing '拷贝code-server失败' (copy code-server failed) on subsequent app launches:

1. Missing await on loadCodeVersion() caused a race condition with permission request and code-server version reading (line 205).

2. Custom code-server path: targetFile.lengthSync() threw when file didn't exist, and copy() always executed even after skip log due to missing if-else guard (lines 237-249).

Closes #96